### PR TITLE
Fix ChatPanel SQL file format detection

### DIFF
--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -1849,7 +1849,7 @@ const ChatPanel = ({ width, getAllAvailableFiles }) => {
                   console.log(`📝 Creating new ${fileConfig.displayName} file with streaming:`, fileName, 'with ID:', memoryFileId, '| Format:', effectiveOutputFormat);
                   
                   // Create empty memory file and start streaming
-                  addMemoryFile(memoryFileId, fileName, fileConfig.type, '');
+                  addMemoryFile(memoryFileId, fileName, '', fileConfig.type);
                   startMemoryFileStreaming(memoryFileId);
                   console.log(`🌊 Started streaming for new ${fileConfig.displayName} file`);
                   


### PR DESCRIPTION
- Fixed incorrect parameter order in addMemoryFile call on line 1852
- Parameters were: (id, name, type, content) - WRONG
- Should be: (id, name, content, type) - CORRECT
- This was causing SQL files to be created with 'text' type instead of 'sql'
- SQL files from ChatPanel now render correctly as SQL in MonacoEditor
- Resolves issue where SQL option created Python-formatted files

Fixes: SQL files incorrectly rendered as Python in MonacoEditor